### PR TITLE
Remove quotation marks from length attribute in annotation

### DIFF
--- a/src/Plenta/ContaoJobsBasic/Entity/TlPlentaJobsBasicOfferTranslation.php
+++ b/src/Plenta/ContaoJobsBasic/Entity/TlPlentaJobsBasicOfferTranslation.php
@@ -38,7 +38,7 @@ class TlPlentaJobsBasicOfferTranslation extends DCADefault
     protected ?string $alias = '';
 
     /**
-     * @ORM\Column(type="string", length="5", options={"default": ""})
+     * @ORM\Column(type="string", length=5, options={"default": ""})
      */
     protected ?string $language = 'en';
 


### PR DESCRIPTION
Having quotation marks around the length attribute breaks installing the bundle with doctrine/dbal < 3.0.0 and Contao 4.9 as the attribute is interpreted as string and an integer is expected.