### PR TITLE
Add that 'noindex/nofollow' excludes jobs from sitemap

### DIFF
--- a/src/Plenta/ContaoJobsBasic/EventListener/Contao/GetSearchablePagesListener.php
+++ b/src/Plenta/ContaoJobsBasic/EventListener/Contao/GetSearchablePagesListener.php
@@ -26,6 +26,10 @@ class GetSearchablePagesListener
         $jobs = PlentaJobsBasicOfferModel::findBy(['published = ?', '(start = ? OR start > ?)', '(stop = ? or stop < ?)'], [1, '', $time, '', $time]);
         if ($jobs) {
             foreach ($jobs as $job) {
+                if ($job->robots === 'noindex,nofollow') {
+                    continue;
+                }
+                
                 if ($page = $job->getAbsoluteUrl($language)) {
                     $pages[] = $page;
                 }


### PR DESCRIPTION
Job offers with robots tag 'noindex/nofollow' should not appear in the XML sitemap as it is the behavior with pages or news posts. This change would make it possible to preview job offers e. g. to clients without Google trying to index the pages.